### PR TITLE
add EqualByValues<T> little class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,3 @@ NFluent.userprefs
 NFluent.Tests/test-results/NFluent.Tests.csproj-Debug-2014-02-24.xml
 
 NFluent.Tests/test-results/NFluent.Tests.csproj.test-cache
-/.vs/Value/v15/Server/sqlite3/db.lock
-/.vs/Value/v15/Server/sqlite3/storage.ide
-/.vs/Value/v15/Server/sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ NFluent.userprefs
 NFluent.Tests/test-results/NFluent.Tests.csproj-Debug-2014-02-24.xml
 
 NFluent.Tests/test-results/NFluent.Tests.csproj.test-cache
+/.vs/Value/v15/Server/sqlite3/db.lock
+/.vs/Value/v15/Server/sqlite3/storage.ide
+/.vs/Value/v15/Server/sqlite3

--- a/Value.Net45/Value.Net45.csproj
+++ b/Value.Net45/Value.Net45.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>Value</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Value.Net45/Value.Net45.csproj
+++ b/Value.Net45/Value.Net45.csproj
@@ -10,9 +10,7 @@
     <RootNamespace>Value</RootNamespace>
     <AssemblyName>Value</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <FileAlignment>512</FileAlignment> 
   </PropertyGroup>
   <PropertyGroup>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Value.Tests/EqualByValuesTest.cs
+++ b/Value.Tests/EqualByValuesTest.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Value.Shared;
+
+namespace Value.Tests
+{
+    [TestFixture]
+    public class EqualByValuesTest
+    {
+        [Test]
+        public void Should_be_equal_by_values()
+        {
+            var coll1 = new string[] { "Hello", "Apple", "C#" };
+            var coll2 = new string[] { "C#", "Hello", "Apple" };
+            Assert.IsTrue(new EqualByValues<string>(coll1, coll2));
+        }
+
+        [Test]
+        public void Should_not_be_equal_by_values()
+        {
+            var coll1 = new string[] { "Hello", "Apple", "C#", "Java" };
+            var coll2 = new string[] { "C#", "Hello", "Apple" };
+            Assert.IsTrue(new EqualByValues<string>(coll1, coll2));
+        }
+    }
+}

--- a/Value.Tests/Value.Tests.csproj
+++ b/Value.Tests/Value.Tests.csproj
@@ -30,11 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NFluent">
-      <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
+    <Reference Include="NFluent, Version=2.0.0.71, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\packages\NFluent.2.0.0\lib\net45\NFluent.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="AmountTests.cs" />
     <Compile Include="DictionaryByValueTests.cs" />
+    <Compile Include="EqualByValuesTest.cs" />
     <Compile Include="SetByValueTests.cs" />
     <Compile Include="Samples\ThreeCards.cs" />
     <Compile Include="Samples\Amount.cs" />
@@ -66,10 +67,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Value.Tests/Value.Tests.csproj
+++ b/Value.Tests/Value.Tests.csproj
@@ -30,11 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NFluent, Version=2.0.0.71, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
-      <HintPath>..\packages\NFluent.2.0.0\lib\net45\NFluent.dll</HintPath>
+    <Reference Include="NFluent">
+      <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Value.Tests/packages.config
+++ b/Value.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net45" />
+  <package id="NFluent" version="2.0.0" targetFramework="net45" />
+  <package id="NUnit" version="3.9.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net45" />
 </packages>

--- a/Value.Tests/packages.config
+++ b/Value.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NFluent" version="2.0.0" targetFramework="net45" />
-  <package id="NUnit" version="3.9.0" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net45" />
+  <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/Value/EqualByValues.cs
+++ b/Value/EqualByValues.cs
@@ -1,0 +1,41 @@
+﻿
+namespace Value.Shared
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Determines two collections are equal by values, i.e. ignoring the order of an elements,
+    /// but the exact elements contained.
+    /// </summary>
+    public class EqualByValues<T>  
+    {
+        private IEnumerable<T> _first;
+        private IEnumerable<T> _second;
+
+        public EqualByValues(IEnumerable<T> first, IEnumerable<T> second)
+        {
+            _first = first;
+            _second = second;
+        }
+
+        public bool Value()
+        {
+            bool ret = true;
+            HashSet<T> set = new HashSet<T>(_first);
+            foreach (var item in _second)
+            {
+                if (!set.Contains(item))
+                {
+                    ret = false;
+                    break;
+                }
+            }
+            return ret;
+        }
+
+        public static implicit operator bool(EqualByValues<T> equalByValues)
+        {
+            return equalByValues.Value();
+        }
+    }
+}

--- a/Value/Value.Shared.projitems
+++ b/Value/Value.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)EquatableByValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EquatableByValueWithoutOrder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ListByValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EqualByValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SetByValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ValueType.cs" />
   </ItemGroup>


### PR DESCRIPTION
I've added a `EqualByValues<T>` class, which determines whether two (any-size) sequences have equal members, and the order of elements doesn't matter.
I've also added some test, but unfortunately unable to run them. I've tested with MsTest.
