### PR TITLE
Implement IReadOnlyDictionary for DictionaryByValue and IReadOnlyList for ListByValue

### DIFF
--- a/Value/DictionaryByValue.cs
+++ b/Value/DictionaryByValue.cs
@@ -27,7 +27,7 @@ namespace Value.Shared
     /// <remarks>This type is not thread-safe (for hashcode updates).</remarks>
     /// <typeparam name="K">The type of keys in the dictionary.</typeparam>
     /// <typeparam name="V">The type of values in the dictionary.</typeparam>
-    public class DictionaryByValue<K, V> : EquatableByValueWithoutOrder<DictionaryByValue<K, V>>, IDictionary<K, V>
+    public class DictionaryByValue<K, V> : EquatableByValueWithoutOrder<DictionaryByValue<K, V>>, IDictionary<K, V>, IReadOnlyDictionary<K, V>
     {
         private readonly IDictionary<K, V> dictionary;
 
@@ -132,5 +132,9 @@ namespace Value.Shared
         public ICollection<K> Keys => dictionary.Keys;
 
         public ICollection<V> Values => dictionary.Values;
+
+        IEnumerable<K> IReadOnlyDictionary<K, V>.Keys => dictionary.Keys;
+
+        IEnumerable<V> IReadOnlyDictionary<K, V>.Values => dictionary.Values;
     }
 }

--- a/Value/ListByValue.cs
+++ b/Value/ListByValue.cs
@@ -27,7 +27,7 @@ namespace Value
     /// </summary>
     /// <remarks>This type is not thread-safe (for hashcode updates).</remarks>
     /// <typeparam name="T">Type of the listed items.</typeparam>
-    public class ListByValue<T> : EquatableByValue<ListByValue<T>>, IList<T>
+    public class ListByValue<T> : EquatableByValue<ListByValue<T>>, IList<T>, IReadOnlyList<T>
     {
         private readonly IList<T> list;
 


### PR DESCRIPTION
I needed to use `DictionaryByValue<K, V>` and `ListByValue<T>` as read-only properties in a class. To support this, I implemented the `IReadOnlyDictionary<K, V>` interface for `DictionaryByValue<K, V>` and the `IReadOnlyList<T>` interface for `ListByValue<T>`. This allows these containers to be used in scenarios where read-only access is required.